### PR TITLE
limited mobile device support

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,11 +90,19 @@ function fetchFlacSamples() {
 
 // Set up audio (this must be called from a user interaction event handler)
 function initAudioSystem() {
-    AUDIO.ctx = new (window.AudioContext || window.webkitAudioContext)();
-    AUDIO.ctx.resume().then(() => {
-        MUTE_BTN.classList.add('mute');
-        MUTE_BTN.textContent = 'mute';
-    });
+    const context = window.AudioContext || window.webkitAudioContext;
+    if(!context) {
+        console.log("AudioContext not available (Lockdown Mode enabled?)");
+        alert("The WebAudio API is disabled, so I can't play sounds. For iOS "
+            + "with Lockdown Mode enabled, you could try disabling Lockdown "
+            + "Mode for this page (\"AA\" menu in URL bar).");
+    } else {
+        AUDIO.ctx = new context();
+        AUDIO.ctx.resume().then(() => {
+            MUTE_BTN.classList.add('mute');
+            MUTE_BTN.textContent = 'mute';
+        });
+    }
 }
 
 // Add audio playback enable function to the play button
@@ -393,7 +401,13 @@ function midiFail(obj) {
 
 // Start the process of getting access to MIDI devices.
 // This should trigger a browser permission authorization dialog box.
-navigator.requestMIDIAccess().then(midiOK, midiFail);
+try {
+    navigator.requestMIDIAccess().then(midiOK, midiFail);
+}
+catch(e) {
+    console.log("This browser does not support WebMIDI API, so no MIDI input");
+    MIDI_IN.textContent = "[MIDI input not supported by this browser]";
+}
 
 // Load FLAC sample files
 fetchFlacSamples();


### PR DESCRIPTION
As far as I know, WebMIDI doesn't work on mobile, and there's nothing I can do about it. But, it is possible to provide better UI feedback about missing APIs and to get drum pad touch triggers working.

This adds some error handling logic to deal more gracefully with the possibility that WebMIDI and WebAudio APIs may not be available. I was surprised to learn that iPadOS Lockdown Mode completely disables WebAudio (AudioContext is undefined). But, it's possible to work around that because Lockdown Mode can be disabled for individual sites ("AA" menu on left end of URL bar).